### PR TITLE
add optimized serialization methods

### DIFF
--- a/serialization.go
+++ b/serialization.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 )
 
 const smallEncoding int32 = 2
@@ -55,6 +56,39 @@ func (t TDigest) AsBytes() ([]byte, error) {
 	}
 
 	return buffer.Bytes(), nil
+}
+
+// ToBytes serializes into the supplied slice, avoiding allocation if the slice
+// is large enough. The result slice is returned.
+func (t *TDigest) ToBytes(b []byte) []byte {
+	requiredSize := 16 + (4 * len(t.summary.keys)) + (len(t.summary.counts) * binary.MaxVarintLen64)
+
+	if cap(b) < requiredSize {
+		b = make([]byte, requiredSize)
+	}
+
+	// The binary.Put* functions helpfully don't extend the slice for you, they
+	// just panic if it's not already long enough. So pre-set the slice length;
+	// we'll return it with the actual encoded length.
+	b = b[:cap(b)]
+
+	endianess.PutUint32(b[0:], uint32(smallEncoding))
+	endianess.PutUint64(b[4:], math.Float64bits(t.compression))
+	endianess.PutUint32(b[12:], uint32(t.summary.Len()))
+
+	var x float64
+	idx := 16
+	for _, mean := range t.summary.keys {
+		delta := mean - x
+		x = mean
+		endianess.PutUint32(b[idx:], math.Float32bits(float32(delta)))
+		idx += 4
+	}
+
+	for _, count := range t.summary.counts {
+		idx += binary.PutUvarint(b[idx:], count)
+	}
+	return b[:idx]
 }
 
 // FromBytes reads a byte buffer with a serialized digest (from AsBytes)
@@ -110,6 +144,61 @@ func FromBytes(buf *bytes.Reader) (*TDigest, error) {
 	}
 
 	return t, nil
+}
+
+// FromBytes deserializes into the supplied TDigest struct, re-using and
+// overwriting any existing buffers.
+func (t *TDigest) FromBytes(buf []byte) error {
+	if len(buf) < 16 {
+		return errors.New("buffer too small for deserialization")
+	}
+
+	encoding := int32(endianess.Uint32(buf[0:]))
+	if encoding != smallEncoding {
+		return fmt.Errorf("unsupported encoding version: %d", encoding)
+	}
+
+	compression := math.Float64frombits(endianess.Uint64(buf[4:]))
+	numCentroids := int(endianess.Uint32(buf[12:]))
+	if numCentroids < 0 || numCentroids > 1<<22 {
+		return errors.New("bad number of centroids in serialization")
+	}
+
+	if len(buf) < 16+(4*numCentroids) {
+		return errors.New("buffer too small for deserialization")
+	}
+
+	t.count = 0
+	t.compression = compression
+	if t.summary == nil || cap(t.summary.keys) < numCentroids || cap(t.summary.counts) < numCentroids {
+		t.summary = newSummary(uint(numCentroids))
+	}
+	t.summary.keys = t.summary.keys[:numCentroids]
+	t.summary.counts = t.summary.counts[:numCentroids]
+
+	idx := 16
+	var delta float32
+	var x float64
+	for i := 0; i < int(numCentroids); i++ {
+		delta = math.Float32frombits(endianess.Uint32(buf[idx:]))
+		idx += 4
+		x += float64(delta)
+		t.summary.keys[i] = x
+	}
+
+	for i := 0; i < int(numCentroids); i++ {
+		count, read := binary.Uvarint(buf[idx:])
+		if read < 1 {
+			return errors.New("error decoding varint, this TDigest is now invalid")
+		}
+
+		idx += read
+
+		t.summary.counts[i] = count
+		t.count += count
+	}
+
+	return nil
 }
 
 func encodeUint(buf *bytes.Buffer, n uint64) error {

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"math"
 	"math/rand"
+	"reflect"
 	"testing"
 )
 
@@ -40,6 +41,88 @@ func TestSerialization(t *testing.T) {
 
 	if t1.count != t2.count || t1.summary.Len() != t2.summary.Len() || t1.compression != t2.compression {
 		t.Errorf("Deserialized to something different. t1=%v t2=%v serialized=%v", t1, t2, serialized)
+	}
+
+	var toBuf []byte
+	toBuf = t1.ToBytes(toBuf)
+	if !reflect.DeepEqual(serialized, toBuf) {
+		t.Errorf("ToBytes serialized to something else")
+	}
+
+	// Make sure we don't re-allocate on buffer re-use
+	toBuf2 := t1.ToBytes(toBuf[:0])
+	if &toBuf2[0] != &toBuf[0] {
+		t.Errorf("Expected ToBytes() to re-use supplied slice")
+	}
+	if !reflect.DeepEqual(toBuf2, toBuf) {
+		t.Errorf("ToBytes serialized to something else")
+	}
+
+	t3 := &TDigest{}
+	err := t3.FromBytes(serialized)
+	if err != nil {
+		t.Error(err)
+	}
+	if t1.count != t3.count || t1.summary.Len() != t3.summary.Len() || t1.compression != t3.compression {
+		t.Errorf("Deserialized to something different. t1=%v t3=%v serialized=%v", t1, t3, serialized)
+	}
+	if !reflect.DeepEqual(t2, t3) {
+		t.Errorf("FromBytes method deserialized to something different from FromBytes function")
+	}
+
+	// Mess up t3's internal state, deserialize again.
+	t3.compression = 2
+	t3.count = 1000
+	t3.summary.keys = append(t3.summary.keys, 2.0)
+	t3.summary.counts[0] = 0
+	err = t3.FromBytes(serialized)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(t2, t3) {
+		t.Errorf("FromBytes method deserialized to something different from FromBytes function")
+	}
+
+	wrong := serialized[:50]
+	err = t3.FromBytes(wrong)
+	if err == nil {
+		t.Error("expected error")
+	}
+	wrong = wrong[:2]
+	err = t3.FromBytes(wrong)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestLargeSerializaton(t *testing.T) {
+	t1 := New(10)
+
+	for i := 0; i < 100000; i++ {
+		t1.Add(rand.Float64(), 1)
+	}
+
+	serialized, _ := t1.AsBytes()
+	serialized2 := t1.ToBytes(nil)
+	if !reflect.DeepEqual(serialized, serialized2) {
+		t.Error("serialized version differ")
+	}
+
+	t2, err := FromBytes(bytes.NewReader(serialized))
+	if err != nil {
+		t.Error(err)
+	}
+
+	var t3 TDigest
+	err = t3.FromBytes(serialized2)
+	if err != nil {
+		t.Error(err)
+	}
+	if t1.count != t2.count || t1.summary.Len() != t2.summary.Len() || t1.compression != t2.compression {
+		t.Errorf("Deserialized to something different. t1=%v t2=%v serialized=%v", t1, t2, serialized)
+	}
+	if t1.count != t3.count || t1.summary.Len() != t3.summary.Len() || t1.compression != t3.compression {
+		t.Errorf("Deserialized to something different. t1=%v t3=%v serialized=%v", t1, t3, serialized)
 	}
 }
 
@@ -85,4 +168,69 @@ func TestJavaSmallBytesCompat(t *testing.T) {
 	assertDifferenceSmallerThan(tdigest, 0.99, 0.005, t)
 	assertDifferenceSmallerThan(tdigest, 0.001, 0.001, t)
 	assertDifferenceSmallerThan(tdigest, 0.999, 0.001, t)
+}
+
+func BenchmarkAsBytes(b *testing.B) {
+	b.ReportAllocs()
+
+	t1 := New(100)
+	for i := 0; i < 100; i++ {
+		t1.Add(rand.Float64(), 1)
+	}
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		t1.AsBytes()
+	}
+}
+
+func BenchmarkToBytes(b *testing.B) {
+	b.ReportAllocs()
+
+	t1 := New(100)
+	for i := 0; i < 100; i++ {
+		t1.Add(rand.Float64(), 1)
+	}
+
+	b.ResetTimer()
+	var buf []byte
+	for n := 0; n < b.N; n++ {
+		buf = t1.ToBytes(buf)
+	}
+}
+
+func BenchmarkFromBytes(b *testing.B) {
+	b.ReportAllocs()
+
+	t1 := New(100)
+	for i := 0; i < 100; i++ {
+		t1.Add(rand.Float64(), 1)
+	}
+
+	buf, _ := t1.AsBytes()
+	reader := bytes.NewReader(buf)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		reader.Reset(buf)
+		FromBytes(reader)
+	}
+}
+
+func BenchmarkFromBytesMethod(b *testing.B) {
+	b.ReportAllocs()
+
+	t1 := New(100)
+	for i := 0; i < 100; i++ {
+		t1.Add(rand.Float64(), 1)
+	}
+
+	buf, _ := t1.AsBytes()
+
+	b.ResetTimer()
+	var t2 TDigest
+	for n := 0; n < b.N; n++ {
+		t2.FromBytes(buf)
+	}
 }


### PR DESCRIPTION
Add binary-compatible serialization/deserialization which avoids allocating memory unless absolutely necessary. `ToBytes` is applicable anywhere you need to send multiple digests across the wire, `FromBytes` is a little stranger since it obliterates the existing digest. But our use case can take advantage of this in many cases.

Note rather substantial performance delta between old and new methodologies.

```
BenchmarkAsBytes-4           	  100000	     12925 ns/op	    1960 B/op	     209 allocs/op
BenchmarkToBytes-4           	 2000000	       634 ns/op	       0 B/op	       0 allocs/op
BenchmarkFromBytes-4         	   50000	     32229 ns/op	   17808 B/op	     112 allocs/op
BenchmarkFromBytesMethod-4   	 2000000	       836 ns/op	       0 B/op	       0 allocs/op
```