### PR TITLE
improved sumUntil implementation

### DIFF
--- a/tdigest.go
+++ b/tdigest.go
@@ -211,7 +211,7 @@ func (t *TDigest) threshold(q float64) float64 {
 }
 
 func (t *TDigest) computeCentroidQuantile(c *centroid) float64 {
-	cumSum := t.summary.sumUntilMean(c.mean)
+	cumSum := t.summary.sumUntilIndex(c.index)
 	return (float64(c.count)/2.0 + float64(cumSum)) / float64(t.count)
 }
 


### PR DESCRIPTION
About half the improvement comes from changing to a conventional integer-based `for`, and half from unrolling the loop.

Loop unrolls, man. I did a lot of that in 90's.

Relevant benchmarks:

```
BenchmarkAdd1-4                 72.5          72.8          +0.41%
BenchmarkAdd10-4                210           156           -25.71%
BenchmarkAdd100-4               863           429           -50.29%
BenchmarkAddOrdered-4           2711          1415          -47.81%
BenchmarkMerge-4                242377        180568        -25.50%
BenchmarkMergeDestructive-4     178605        127054        -28.86%
```